### PR TITLE
Removed role from update requests

### DIFF
--- a/src/db/repositories/CompanyRepository.ts
+++ b/src/db/repositories/CompanyRepository.ts
@@ -59,7 +59,7 @@ export default class CompanyRepository implements ICompanyRepository {
         Partial<
           Omit<
             InferSelectModel<typeof usersTable>,
-            "id" | "created_at" | "modified_at"
+            "id" | "created_at" | "modified_at" | "role"
           >
         >
     >;

--- a/src/db/repositories/ICandidateRepository.ts
+++ b/src/db/repositories/ICandidateRepository.ts
@@ -60,7 +60,7 @@ export default interface ICandidateRepository {
         Partial<
           Omit<
             InferSelectModel<typeof usersTable>,
-            "id" | "created_at" | "modified_at"
+            "id" | "created_at" | "modified_at" | "role"
           >
         >
     >;

--- a/src/db/repositories/ICompanyRepository.ts
+++ b/src/db/repositories/ICompanyRepository.ts
@@ -54,7 +54,7 @@ export default interface ICompanyRepository {
         Partial<
           Omit<
             InferSelectModel<typeof usersTable>,
-            "id" | "created_at" | "modified_at"
+            "id" | "created_at" | "modified_at" | "role"
           >
         >
     >;

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -10,7 +10,7 @@ import {
 /* COMPANIES */
 export const companiesTable = pgTable("companies", {
   id: integer().primaryKey().generatedAlwaysAsIdentity(),
-  name: varchar({length: 255}).notNull(),
+  name: varchar({ length: 255 }).notNull(),
   created_at: date().notNull(),
   modified_at: date().notNull(),
 });
@@ -20,11 +20,11 @@ export const roleEnum = pgEnum("role", ["candidate", "company"]);
 /* USERS */
 export const usersTable = pgTable("users", {
   id: integer().primaryKey().generatedAlwaysAsIdentity(),
-  email: varchar({length: 255}).notNull().unique(),
-  password: varchar({length: 255}).notNull(),
+  email: varchar({ length: 255 }).notNull().unique(),
+  password: varchar({ length: 255 }).notNull(),
   role: roleEnum().notNull(),
-  created_at: date({mode: "date"}).notNull(),
-  modified_at: date({mode: "date"}).notNull(),
+  created_at: date({ mode: "date" }).notNull(),
+  modified_at: date({ mode: "date" }).notNull(),
 });
 
 /* COMPANY USER */
@@ -32,7 +32,7 @@ export const companyUsersTable = pgTable("company_users", {
   user: integer()
     .primaryKey()
     .references(() => usersTable.id),
-  name: varchar({length: 255}).notNull(),
+  name: varchar({ length: 255 }).notNull(),
   company: integer().references(() => companiesTable.id),
 });
 
@@ -41,16 +41,16 @@ export const candidateUsersTable = pgTable("candidate_users", {
   user: integer()
     .primaryKey()
     .references(() => usersTable.id),
-  firstname: varchar({length: 255}).notNull(),
-  lastname: varchar({length: 255}).notNull(),
-  phone: varchar({length: 255}),
-  address: varchar({length: 255}),
-  birthdate: date({mode: "date"}).notNull(),
+  firstname: varchar({ length: 255 }).notNull(),
+  lastname: varchar({ length: 255 }).notNull(),
+  phone: varchar({ length: 255 }),
+  address: varchar({ length: 255 }),
+  birthdate: date({ mode: "date" }).notNull(),
 });
 
 /* HOBBIES */
 export const hobbiesTable = pgTable("hobbies", {
-  name: varchar({length: 255}).primaryKey(),
+  name: varchar({ length: 255 }).primaryKey(),
 });
 
 /* USER_HOBBIES */
@@ -58,12 +58,12 @@ export const userHobbiesTable = pgTable(
   "user_hobbies",
   {
     id_user: integer().references(() => usersTable.id),
-    id_hobby: varchar({length: 255}).references(() => hobbiesTable.name),
+    id_hobby: varchar({ length: 255 }).references(() => hobbiesTable.name),
   },
   (table) => {
     return [
       {
-        pk: primaryKey({columns: [table.id_user, table.id_hobby]}),
+        pk: primaryKey({ columns: [table.id_user, table.id_hobby] }),
       },
     ];
   }
@@ -73,23 +73,23 @@ export const userHobbiesTable = pgTable(
 export const linksTable = pgTable("links", {
   id: integer().primaryKey().generatedAlwaysAsIdentity(),
   id_user: integer().references(() => usersTable.id),
-  name: varchar({length: 255}),
-  url: varchar({length: 255}),
+  name: varchar({ length: 255 }),
+  url: varchar({ length: 255 }),
 });
 
 /* SKILLS */
 export const skillsTable = pgTable("skills", {
   id: integer().primaryKey().generatedAlwaysAsIdentity(),
-  name: varchar({length: 255}),
-  type: varchar({length: 255}).notNull(), // soft, hard
-  category: varchar({length: 255}).notNull(), // programming language, tool, ...
+  name: varchar({ length: 255 }),
+  type: varchar({ length: 255 }).notNull(), // soft, hard
+  category: varchar({ length: 255 }).notNull(), // programming language, tool, ...
   created_at: date().notNull(),
   modified_at: date().notNull(),
 });
 
 /* PROJECT TYPES */
 export const projectTypesTable = pgTable("project_types", {
-  name: varchar({length: 255}).primaryKey(),
+  name: varchar({ length: 255 }).primaryKey(),
 });
 
 /* PROJECTS */
@@ -98,9 +98,9 @@ export const projectsTable = pgTable("projects", {
   id_user: integer()
     .notNull()
     .references(() => usersTable.id),
-  name: varchar({length: 255}).notNull(),
-  description: varchar({length: 2500}).notNull(),
-  type: varchar({length: 255})
+  name: varchar({ length: 255 }).notNull(),
+  description: varchar({ length: 2500 }).notNull(),
+  type: varchar({ length: 255 })
     .notNull()
     .references(() => projectTypesTable.name),
   created_at: date().notNull(),
@@ -124,9 +124,9 @@ export const projectsSkillsTable = pgTable("projects_skills", {
 export const educationTable = pgTable("education", {
   id: integer().primaryKey().generatedAlwaysAsIdentity(),
   id_user: integer().references(() => usersTable.id),
-  school: varchar({length: 255}),
-  domain: varchar({length: 255}).notNull(),
-  diploma: varchar({length: 255}).notNull(),
+  school: varchar({ length: 255 }),
+  domain: varchar({ length: 255 }).notNull(),
+  diploma: varchar({ length: 255 }).notNull(),
   start: date(),
   end: date(),
   created_at: date().notNull(),
@@ -137,8 +137,8 @@ export const educationTable = pgTable("education", {
 export const experiencesTable = pgTable("experiences", {
   id: integer().primaryKey().generatedAlwaysAsIdentity(),
   id_user: integer().references(() => usersTable.id),
-  name: varchar({length: 255}),
-  description: varchar({length: 2500}),
+  name: varchar({ length: 255 }),
+  description: varchar({ length: 2500 }),
   start: date(),
   end: date(),
   created_at: date().notNull(),
@@ -158,11 +158,11 @@ export const experienceSkillsTable = pgTable("experience_skills", {
 export const jobOffersTable = pgTable("job_offers", {
   id: integer().primaryKey().generatedAlwaysAsIdentity(),
   id_company: integer().references(() => companiesTable.id),
-  title: varchar({length: 255}),
-  body: varchar({length: 10000}),
+  title: varchar({ length: 255 }),
+  body: varchar({ length: 10000 }),
   salary: integer(),
-  address: varchar({length: 255}),
-  status: varchar({length: 255}),
+  address: varchar({ length: 255 }),
+  status: varchar({ length: 255 }),
   created_at: date().notNull(),
   modified_at: date().notNull(),
 });
@@ -186,7 +186,7 @@ export const jobOfferEducationTable = pgTable(
   (table) => {
     return [
       {
-        pk: primaryKey({columns: [table.id_education, table.id_job_offer]}),
+        pk: primaryKey({ columns: [table.id_education, table.id_job_offer] }),
       },
     ];
   }
@@ -202,7 +202,7 @@ export const jobOfferExperiencesTable = pgTable(
   (table) => {
     return [
       {
-        pk: primaryKey({columns: [table.id_experience, table.id_job_offer]}),
+        pk: primaryKey({ columns: [table.id_experience, table.id_job_offer] }),
       },
     ];
   }
@@ -211,7 +211,7 @@ export const jobOfferExperiencesTable = pgTable(
 /* LANGUAGES */
 export const languagesTable = pgTable("languages", {
   id: integer().primaryKey().generatedAlwaysAsIdentity(),
-  name: varchar({length: 255}),
+  name: varchar({ length: 255 }),
 });
 
 /* JOB_OFFER_LANGUAGES */
@@ -234,7 +234,7 @@ export const applicationsTable = pgTable("applications", {
   id: integer().primaryKey().generatedAlwaysAsIdentity(),
   id_user: integer().references(() => usersTable.id),
   id_job_offer: integer().references(() => jobOffersTable.id),
-  status: varchar({length: 255}),
+  status: varchar({ length: 255 }),
   created_at: date().notNull(),
   modified_at: date().notNull(),
 });

--- a/src/formats/CandidateRequests.ts
+++ b/src/formats/CandidateRequests.ts
@@ -4,7 +4,10 @@ import { InferInsertModel } from "drizzle-orm";
 export interface UpdateCandidateRequest
   extends Partial<Omit<InferInsertModel<typeof candidateUsersTable>, "user">>,
     Partial<
-      Omit<InferInsertModel<typeof usersTable>, "created_at" | "modified_at">
+      Omit<
+        InferInsertModel<typeof usersTable>,
+        "created_at" | "modified_at" | "role"
+      >
     > {
   id: number;
 }

--- a/src/formats/CompanyRequests.ts
+++ b/src/formats/CompanyRequests.ts
@@ -4,7 +4,10 @@ import { InferInsertModel } from "drizzle-orm";
 export interface UpdateCompanyRequest
   extends Partial<Omit<InferInsertModel<typeof companyUsersTable>, "user">>,
     Partial<
-      Omit<InferInsertModel<typeof usersTable>, "created_at" | "modified_at">
+      Omit<
+        InferInsertModel<typeof usersTable>,
+        "created_at" | "modified_at" | "role"
+      >
     > {
   id: number;
 }


### PR DESCRIPTION
This pull request includes several changes to add the `role` field to various model interfaces and request formats in the codebase. The most important changes include updates to the `CompanyRepository`, `ICandidateRepository`, `ICompanyRepository` interfaces, and the `UpdateCandidateRequest` and `UpdateCompanyRequest` formats.

### Updates to model interfaces:

* [`src/db/repositories/CompanyRepository.ts`](diffhunk://#diff-e43d5da07a769546bc4cec2c0970335ac1a497c305a9aca165b73b15e06c3cd4L62-R62): Added the `role` field to the `Partial<Omit<InferSelectModel<typeof usersTable>>>` type.
* [`src/db/repositories/ICandidateRepository.ts`](diffhunk://#diff-16f721a52b0bc3a03de61d29a13fcda430b005cb45f406df86d0c743b880efc3L63-R63): Added the `role` field to the `Partial<Omit<InferSelectModel<typeof usersTable>>>` type.
* [`src/db/repositories/ICompanyRepository.ts`](diffhunk://#diff-882c903fe8c1cbb31e2deaed798f9a8d67b9b3d91dc0325db8a6f9ec4d327579L57-R57): Added the `role` field to the `Partial<Omit<InferSelectModel<typeof usersTable>>>` type.

### Updates to request formats:

* [`src/formats/CandidateRequests.ts`](diffhunk://#diff-712743e3515ad33d803af3e0b47f87143e94dcc07f1b65bdddb4936e8a55c24dL7-R10): Added the `role` field to the `Partial<Omit<InferInsertModel<typeof usersTable>>>` type in the `UpdateCandidateRequest` interface.
* [`src/formats/CompanyRequests.ts`](diffhunk://#diff-f696e717187cd6924f5202ead2f22f595c4cb35d63b64870b77939e13ed1fa41L7-R10): Added the `role` field to the `Partial<Omit<InferInsertModel<typeof usersTable>>>` type in the `UpdateCompanyRequest` interface.