### PR TITLE
Gestion des offres

### DIFF
--- a/src/controllers/AuthenticationController.test.ts
+++ b/src/controllers/AuthenticationController.test.ts
@@ -114,6 +114,7 @@ describe("AuthenticationController", () => {
         lastname: "Doe",
         password: "password123",
         birthdate: "2025-01-01",
+        address: "123 Main St",
       };
       (mockUserRepository.prototype.findByEmail as jest.Mock).mockResolvedValue(
         { id: 99 }
@@ -133,6 +134,7 @@ describe("AuthenticationController", () => {
         lastname: "Doe",
         password: "password123",
         birthdate: "2025-01-01",
+        address: "123 Main St",
       };
       (mockUserRepository.prototype.findByEmail as jest.Mock).mockResolvedValue(
         null
@@ -154,6 +156,7 @@ describe("AuthenticationController", () => {
         lastname: "Doe",
         password: "password123",
         birthdate: "2025-01-01",
+        address: "123 Main St",
       };
       const createdUser = {
         id: 1,

--- a/src/controllers/AuthenticationController.test.ts
+++ b/src/controllers/AuthenticationController.test.ts
@@ -207,6 +207,7 @@ describe("AuthenticationController", () => {
         id: 20,
         user: 10,
         name: request.name,
+        company: 1,
       };
 
       (mockUserRepository.prototype.findByEmail as jest.Mock).mockResolvedValue(
@@ -238,6 +239,7 @@ describe("AuthenticationController", () => {
       expect(mockCompanyRepository.prototype.add).toHaveBeenCalledWith({
         user: createdUser.id,
         name: request.name,
+        company: 1,
       });
       expect(result).toEqual({ token: "mock-token" });
     });

--- a/src/controllers/AuthenticationController.ts
+++ b/src/controllers/AuthenticationController.ts
@@ -6,9 +6,9 @@ import {
   RegisterCompanyRequest,
 } from "../formats/UserRequests";
 import UserRepository from "../db/repositories/UserRepository";
-import {UserCreationError} from "../exceptions/UserExceptions";
-import {TokenProvider} from "../providers/TokenProvider";
-import {LogInResponse, RegisterResponse} from "../formats/UserResponses";
+import { UserCreationError } from "../exceptions/UserExceptions";
+import { TokenProvider } from "../providers/TokenProvider";
+import { LogInResponse, RegisterResponse } from "../formats/UserResponses";
 import CandidateRepository from "../db/repositories/CandidateRepository";
 import CompanyRepository from "../db/repositories/CompanyRepository";
 
@@ -65,9 +65,9 @@ export const registerCandidate = async (
 
   // Return a user token to keep them logged in
   const tokenProvider = new TokenProvider();
-  const token = tokenProvider.sign({id: newUser.id, role: undefined}); // TODO: Add roles later...
+  const token = tokenProvider.sign({ id: newUser.id, role: undefined }); // TODO: Add roles later...
 
-  const response: RegisterResponse = {token: token};
+  const response: RegisterResponse = { token: token };
   return response;
 };
 
@@ -109,6 +109,7 @@ export const registerCompany = async (
   const newCompany = await companyRepository.add({
     user: newUser.id,
     name: request.name,
+    company: 1, // TODO: CREATE A COMPANY PROFILE BEFORE
   });
 
   // Check if the company has been added to the database
@@ -122,9 +123,9 @@ export const registerCompany = async (
 
   // Return a user token to keep them logged in
   const tokenProvider = new TokenProvider();
-  const token = tokenProvider.sign({id: newUser.id, role: undefined}); // TODO: Add roles later...
+  const token = tokenProvider.sign({ id: newUser.id, role: undefined }); // TODO: Add roles later...
 
-  const response: RegisterResponse = {token: token};
+  const response: RegisterResponse = { token: token };
   return response;
 };
 
@@ -145,8 +146,8 @@ export const logIn = async (
   // TODO: Get the corresponding candidate or company user and include their relevant info in the token
 
   const tokenProvider = new TokenProvider();
-  const token = tokenProvider.sign({id: user.id, role: undefined}); // TODO: Add roles later...
+  const token = tokenProvider.sign({ id: user.id, role: undefined }); // TODO: Add roles later...
 
-  const response: LogInResponse = {token: token};
+  const response: LogInResponse = { token: token };
   return response;
 };

--- a/src/controllers/OfferController.ts
+++ b/src/controllers/OfferController.ts
@@ -1,0 +1,47 @@
+import OfferRepository from "../db/repositories/OfferRepository";
+import {
+  AddOfferRequest,
+  GetAllOffersRequest,
+  GetOfferByIdRequest,
+  RemoveOfferRequest,
+  UpdateOfferRequest,
+} from "../formats/OfferRequests";
+import {
+  AddOfferResponse,
+  GetOfferByIdResponse,
+  RemoveOfferResponse,
+  UpdateOfferResponse,
+} from "../formats/OfferResponses";
+
+const offerRepository = new OfferRepository();
+
+export const AddOffer = async (
+  request: AddOfferRequest
+): Promise<AddOfferResponse> => {
+  return await offerRepository.create(request);
+};
+
+export const UpdateOffer = async (
+  request: UpdateOfferRequest
+): Promise<UpdateOfferResponse> => {
+  return await offerRepository.update(request);
+};
+
+export const RemoveOffer = async (
+  request: RemoveOfferRequest
+): Promise<RemoveOfferResponse> => {
+  await offerRepository.delete(request.id);
+  return {};
+};
+
+export const GetOfferById = async (
+  request: GetOfferByIdRequest
+): Promise<GetOfferByIdResponse> => {
+  return await offerRepository.getById(request.id);
+};
+
+export const GetAllOffers = async (
+  request: GetAllOffersRequest
+): Promise<GetOfferByIdResponse[]> => {
+  return await offerRepository.getAll();
+};

--- a/src/db/repositories/IOfferRepository.ts
+++ b/src/db/repositories/IOfferRepository.ts
@@ -30,6 +30,21 @@ export default interface IOfferRepository {
   ): Promise<Offer>;
 
   /**
+   * Updates an existing offer in the repository along with the skills, eduaction, experiences and languages linked to it.
+   * @param offer The offer to update
+   */
+  updateWithLinks(
+    offer: Partial<
+      Omit<Offer, "created_at" | "modified_at"> & {
+        skills: number[];
+        education: number[];
+        experiences: number[];
+        languages: { id: number; level: string }[];
+      }
+    >
+  ): Promise<Offer>;
+
+  /**
    * Deletes an offer from the repository
    * @param id The id of the offer to delete
    */
@@ -40,11 +55,56 @@ export default interface IOfferRepository {
    * @param id The id of the offer to retrieve
    * @returns The corresponding offer
    */
-  getById(id: number): Promise<Offer>;
+  getById(id: number): Promise<
+    Offer & {
+      skills: { id: number; name: string; type: string; category: string }[];
+      education: { id: number; domain: string; diploma: string }[];
+      experiences: { id: number; name: string }[];
+      languages: { id: number; name: string; level: string }[];
+    }
+  >;
 
   /**
    * Retrieves all offers from the repository
    * @returns A list of all offers
    */
-  getAll(): Promise<Offer[]>;
+  getAll(): Promise<
+    (Offer & {
+      skills: { id: number; name: string; type: string; category: string }[];
+      education: { id: number; domain: string; diploma: string }[];
+      experiences: { id: number; name: string }[];
+      languages: { id: number; name: string; level: string }[];
+    })[]
+  >;
+
+  /**
+   * Adds skills to an offer
+   * @param offerId The id of the offer to add skills to
+   * @param skills The ids of the skills to add to the offer
+   */
+  addSkills(offerId: number, skills: number[]): Promise<null>;
+
+  /**
+   * Adds education requirements to an offer
+   * @param offerId The id of the offer to add education requirements to
+   * @param education The ids of the education requirements to add to the offer
+   */
+  addEducation(offerId: number, education: number[]): Promise<null>;
+
+  /**
+   * Adds experiences to an offer
+   * @param offerId The id of the offer to add experiences to
+   * @param experiences The ids of the experiences to add to the offer
+   */
+  addExperiences(offerId: number, experiences: number[]): Promise<null>;
+
+  /**
+   * Adds languages to an offer
+   * @param offerId The id of the offer to add languages to
+   * @param languages The ids of the languages to add to the offer
+   */
+  addLanguages(
+    offerId: number,
+    languages: { id: number; level: string }[]
+  ): Promise<null>;
 }

--- a/src/db/repositories/IOfferRepository.ts
+++ b/src/db/repositories/IOfferRepository.ts
@@ -1,0 +1,50 @@
+import { InferInsertModel, InferSelectModel } from "drizzle-orm";
+import { jobOffersTable } from "../schema";
+
+type Offer = InferSelectModel<typeof jobOffersTable>;
+type OfferInsert = InferInsertModel<typeof jobOffersTable>;
+
+/**
+ * Interface defining the contract for interacting with the Offer repository.
+ * Provides CRUD operations for managing offer entities in the database.
+ */
+export default interface IOfferRepository {
+  /**
+   * Creates a new offer in the repository
+   * @param offer The offer to create, excluding created_at and modified_at fields
+   * @returns Promise that resolves to the created Offer
+   * @throws {Error} If the offer creation fails
+   */
+  create(
+    offer: Omit<OfferInsert, "created_at" | "modified_at">
+  ): Promise<Offer>;
+
+  /**
+   * Updates an existing offer in the repository
+   * @param offer Partial offer data to update, excluding created_at and modified_at fields
+   * @returns Promise that resolves to the updated Offer
+   * @throws {Error} If the offer update fails or offer not found
+   */
+  update(
+    offer: Partial<Omit<OfferInsert, "created_at" | "modified_at">>
+  ): Promise<Offer>;
+
+  /**
+   * Deletes an offer from the repository
+   * @param id The id of the offer to delete
+   */
+  delete(id: number): Promise<null>;
+
+  /**
+   * Retrieves an offer from the repository by its id
+   * @param id The id of the offer to retrieve
+   * @returns The corresponding offer
+   */
+  getById(id: number): Promise<Offer>;
+
+  /**
+   * Retrieves all offers from the repository
+   * @returns A list of all offers
+   */
+  getAll(): Promise<Offer[]>;
+}

--- a/src/db/repositories/OfferRepository.ts
+++ b/src/db/repositories/OfferRepository.ts
@@ -1,5 +1,15 @@
 import { InferSelectModel, InferInsertModel, eq } from "drizzle-orm";
-import { jobOffersTable } from "../schema";
+import {
+  educationTable,
+  experiencesTable,
+  jobOfferEducationTable,
+  jobOfferExperiencesTable,
+  jobOfferLanguagesTable,
+  jobOfferSkillsTable,
+  jobOffersTable,
+  languagesTable,
+  skillsTable,
+} from "../schema";
 import IOfferRepository from "./IOfferRepository";
 import { db } from "..";
 
@@ -39,17 +49,260 @@ export default class OfferRepository implements IOfferRepository {
     )[0];
   }
 
+  async updateWithLinks(
+    offer: Partial<
+      Omit<Offer, "id" | "created_at" | "modified_at"> & {
+        skills: number[];
+        education: number[];
+        experiences: number[];
+        languages: { id: number; level: string }[];
+      }
+    > & {
+      id: number;
+    }
+  ): Promise<Offer> {
+    const { id, skills, education, experiences, languages, ...updateFields } =
+      offer;
+
+    const updatedOffer = (
+      await db
+        .update(jobOffersTable)
+        .set({ ...updateFields, modified_at: new Date().toISOString() })
+        .where(eq(jobOffersTable.id, id))
+        .returning()
+    )[0];
+
+    // Update skills
+    await db
+      .delete(jobOfferSkillsTable)
+      .where(eq(jobOfferSkillsTable.id_job_offer, id));
+    if (skills && skills.length > 0)
+      await db
+        .insert(jobOfferSkillsTable)
+        .values(
+          skills.map((id_skill) => ({ id_job_offer: id, id_skill: id_skill }))
+        );
+
+    // Update education
+    await db
+      .delete(jobOfferEducationTable)
+      .where(eq(jobOfferEducationTable.id_job_offer, id));
+    if (education && education.length > 0)
+      await db.insert(jobOfferEducationTable).values(
+        education.map((id_education) => ({
+          id_job_offer: id,
+          id_education: id_education,
+        }))
+      );
+
+    // Update experiences
+    await db
+      .delete(jobOfferExperiencesTable)
+      .where(eq(jobOfferExperiencesTable.id_job_offer, id));
+    if (experiences && experiences.length > 0)
+      await db.insert(jobOfferExperiencesTable).values(
+        experiences.map((id_experience) => ({
+          id_job_offer: id,
+          id_experience: id_experience,
+        }))
+      );
+
+    // Update languages
+    await db
+      .delete(jobOfferLanguagesTable)
+      .where(eq(jobOfferLanguagesTable.id_job_offer, id));
+    if (languages && languages.length > 0)
+      await db.insert(jobOfferLanguagesTable).values(
+        languages.map(({ id: id_language, level }) => ({
+          id_job_offer: id,
+          id_language: id_language,
+          level: level,
+        }))
+      );
+
+    return updatedOffer;
+  }
+
   async delete(id: number): Promise<null> {
     await db.delete(jobOffersTable).where(eq(jobOffersTable.id, id));
     return null;
   }
 
-  async getById(id: number): Promise<Offer> {
-    return (
+  async getById(id: number): Promise<
+    Offer & {
+      skills: { id: number; name: string; type: string; category: string }[];
+      education: { id: number; domain: string; diploma: string }[];
+      experiences: { id: number; name: string }[];
+      languages: { id: number; name: string; level: string }[];
+    }
+  > {
+    const offer = (
       await db.select().from(jobOffersTable).where(eq(jobOffersTable.id, id))
     )[0];
+
+    return {
+      ...offer,
+      skills: await db
+        .select({
+          id: skillsTable.id,
+          name: skillsTable.name,
+          type: skillsTable.type,
+          category: skillsTable.category,
+        })
+        .from(skillsTable)
+        .innerJoin(
+          jobOfferSkillsTable,
+          eq(skillsTable.id, jobOfferSkillsTable.id_skill)
+        )
+        .where(eq(jobOfferSkillsTable.id_job_offer, id)),
+      education: await db
+        .select({
+          id: educationTable.id,
+          domain: educationTable.domain,
+          diploma: educationTable.diploma,
+        })
+        .from(educationTable)
+        .innerJoin(
+          jobOfferEducationTable,
+          eq(educationTable.id, jobOfferEducationTable.id_education)
+        )
+        .where(eq(jobOfferEducationTable.id_job_offer, id)),
+      experiences: await db
+        .select({
+          id: experiencesTable.id,
+          name: experiencesTable.name,
+        })
+        .from(experiencesTable)
+        .innerJoin(
+          jobOfferExperiencesTable,
+          eq(experiencesTable.id, jobOfferExperiencesTable.id_experience)
+        )
+        .where(eq(jobOfferExperiencesTable.id_job_offer, id)),
+      languages: await db
+        .select({
+          id: languagesTable.id,
+          name: languagesTable.name,
+          level: jobOfferLanguagesTable.level,
+        })
+        .from(languagesTable)
+        .innerJoin(
+          jobOfferLanguagesTable,
+          eq(languagesTable.id, jobOfferLanguagesTable.id_language)
+        )
+        .where(eq(jobOfferLanguagesTable.id_job_offer, id)),
+    };
   }
-  async getAll(): Promise<Offer[]> {
-    return await db.select().from(jobOffersTable);
+
+  async getAll(): Promise<
+    (Offer & {
+      skills: { id: number; name: string; type: string; category: string }[];
+      education: { id: number; domain: string; diploma: string }[];
+      experiences: { id: number; name: string }[];
+      languages: { id: number; name: string; level: string }[];
+    })[]
+  > {
+    const offers = await db.select().from(jobOffersTable);
+
+    return await Promise.all(
+      offers.map(async (offer) => ({
+        ...offer,
+        skills: await db
+          .select({
+            id: skillsTable.id,
+            name: skillsTable.name,
+            type: skillsTable.type,
+            category: skillsTable.category,
+          })
+          .from(skillsTable)
+          .innerJoin(
+            jobOfferSkillsTable,
+            eq(skillsTable.id, jobOfferSkillsTable.id_skill)
+          )
+          .where(eq(jobOfferSkillsTable.id_job_offer, offer.id)),
+        education: await db
+          .select({
+            id: educationTable.id,
+            domain: educationTable.domain,
+            diploma: educationTable.diploma,
+          })
+          .from(educationTable)
+          .innerJoin(
+            jobOfferEducationTable,
+            eq(educationTable.id, jobOfferEducationTable.id_education)
+          )
+          .where(eq(jobOfferEducationTable.id_job_offer, offer.id)),
+        experiences: await db
+          .select({
+            id: experiencesTable.id,
+            name: experiencesTable.name,
+          })
+          .from(experiencesTable)
+          .innerJoin(
+            jobOfferExperiencesTable,
+            eq(experiencesTable.id, jobOfferExperiencesTable.id_experience)
+          )
+          .where(eq(jobOfferExperiencesTable.id_job_offer, offer.id)),
+        languages: await db
+          .select({
+            id: languagesTable.id,
+            name: languagesTable.name,
+            level: jobOfferLanguagesTable.level,
+          })
+          .from(languagesTable)
+          .innerJoin(
+            jobOfferLanguagesTable,
+            eq(languagesTable.id, jobOfferLanguagesTable.id_language)
+          )
+          .where(eq(jobOfferLanguagesTable.id_job_offer, offer.id)),
+      }))
+    );
+  }
+
+  async addSkills(offerId: number, skills: number[]): Promise<null> {
+    await db.insert(jobOfferSkillsTable).values(
+      skills.map((id_skill) => ({
+        id_job_offer: offerId,
+        id_skill: id_skill,
+      }))
+    );
+
+    return null;
+  }
+
+  async addEducation(offerId: number, education: number[]): Promise<null> {
+    await db.insert(jobOfferEducationTable).values(
+      education.map((id_education) => ({
+        id_offer: offerId,
+        id_education: id_education,
+      }))
+    );
+
+    return null;
+  }
+
+  async addExperiences(offerId: number, experiences: number[]): Promise<null> {
+    await db.insert(jobOfferExperiencesTable).values(
+      experiences.map((id_experience) => ({
+        id_offer: offerId,
+        id_experience: id_experience,
+      }))
+    );
+
+    return null;
+  }
+
+  async addLanguages(
+    offerId: number,
+    languages: { id: number; level: string }[]
+  ): Promise<null> {
+    await db.insert(jobOfferLanguagesTable).values(
+      languages.map(({ id, level }) => ({
+        id_job_offer: offerId,
+        id_language: id,
+        level: level,
+      }))
+    );
+
+    return null;
   }
 }

--- a/src/db/repositories/OfferRepository.ts
+++ b/src/db/repositories/OfferRepository.ts
@@ -1,0 +1,55 @@
+import { InferSelectModel, InferInsertModel, eq } from "drizzle-orm";
+import { jobOffersTable } from "../schema";
+import IOfferRepository from "./IOfferRepository";
+import { db } from "..";
+
+type Offer = InferSelectModel<typeof jobOffersTable>;
+type OfferInsert = InferInsertModel<typeof jobOffersTable>;
+
+export default class OfferRepository implements IOfferRepository {
+  async create(
+    offer: Omit<OfferInsert, "created_at" | "modified_at">
+  ): Promise<Offer> {
+    return (
+      await db
+        .insert(jobOffersTable)
+        .values({
+          ...offer,
+          created_at: new Date().toISOString(),
+          modified_at: new Date().toISOString(),
+        })
+        .returning()
+    )[0];
+  }
+
+  async update(
+    offer: Partial<
+      Omit<Offer, "id" | "id_company" | "created_at" | "modified_at">
+    > & {
+      id: number;
+    }
+  ): Promise<Offer> {
+    const { id, ...updateFields } = offer;
+    return (
+      await db
+        .update(jobOffersTable)
+        .set({ ...updateFields, modified_at: new Date().toISOString() })
+        .where(eq(jobOffersTable.id, id))
+        .returning()
+    )[0];
+  }
+
+  async delete(id: number): Promise<null> {
+    await db.delete(jobOffersTable).where(eq(jobOffersTable.id, id));
+    return null;
+  }
+
+  async getById(id: number): Promise<Offer> {
+    return (
+      await db.select().from(jobOffersTable).where(eq(jobOffersTable.id, id))
+    )[0];
+  }
+  async getAll(): Promise<Offer[]> {
+    return await db.select().from(jobOffersTable);
+  }
+}

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -53,22 +53,17 @@ export const candidateUsersTable = pgTable("candidate_users", {
   lookingForExperience: integer(), // 1: junior, 2: confirmed, 3: senior
 });
 
-/* HOBBIES */
-export const hobbiesTable = pgTable("hobbies", {
-  name: varchar({ length: 255 }).primaryKey(),
-});
-
 /* USER_HOBBIES */
 export const userHobbiesTable = pgTable(
   "user_hobbies",
   {
     id_user: integer().references(() => usersTable.id),
-    id_hobby: varchar({ length: 255 }).references(() => hobbiesTable.name),
+    name: varchar({ length: 255 }).notNull(),
   },
   (table) => {
     return [
       {
-        pk: primaryKey({ columns: [table.id_user, table.id_hobby] }),
+        pk: primaryKey({ columns: [table.id_user, table.name] }),
       },
     ];
   }
@@ -276,7 +271,6 @@ export const jobOfferExperiencesTable = pgTable(
 export const languagesTable = pgTable("languages", {
   id: integer().primaryKey().generatedAlwaysAsIdentity(),
   name: varchar({ length: 255 }).notNull(),
-  level: integer().notNull(),
 });
 
 /* JOB_OFFER_LANGUAGES */
@@ -285,6 +279,7 @@ export const jobOfferLanguagesTable = pgTable(
   {
     id_language: integer().references(() => languagesTable.id),
     id_job_offer: integer().references(() => jobOffersTable.id),
+    level: varchar({ length: 255 }).notNull(),
   },
   (table) => {
     return [
@@ -301,7 +296,7 @@ export const usersLanguagesTable = pgTable(
   {
     id_language: integer().references(() => languagesTable.id),
     id_user: integer().references(() => usersTable.id),
-    created_at: date().notNull(),
+    level: varchar({ length: 255 }).notNull(),
   },
   (table) => {
     return [

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -157,14 +157,16 @@ export const experienceSkillsTable = pgTable("experience_skills", {
 /* JOB_OFFERS */
 export const jobOffersTable = pgTable("job_offers", {
   id: integer().primaryKey().generatedAlwaysAsIdentity(),
-  id_company: integer().references(() => companiesTable.id),
-  title: varchar({ length: 255 }),
-  body: varchar({ length: 10000 }),
-  salary: integer(),
-  address: varchar({ length: 255 }),
-  status: varchar({ length: 255 }),
-  created_at: date().notNull(),
-  modified_at: date().notNull(),
+  id_company: integer()
+    .references(() => companiesTable.id)
+    .notNull(),
+  title: varchar({ length: 255 }).notNull(),
+  body: varchar({ length: 10000 }).notNull(),
+  salary: integer().notNull(),
+  address: varchar({ length: 255 }).notNull(),
+  status: varchar({ length: 255 }).notNull(),
+  created_at: date().notNull().notNull(),
+  modified_at: date().notNull().notNull(),
 });
 
 /* JOB_OFFER_SKILLS */

--- a/src/exceptions/OfferExceptions.ts
+++ b/src/exceptions/OfferExceptions.ts
@@ -1,0 +1,6 @@
+export class OfferNotFoundError extends Error {
+  constructor(message?: string) {
+    super(message || "Offer not found");
+    this.name = "OfferNotFoundError";
+  }
+}

--- a/src/formats/OfferRequests.ts
+++ b/src/formats/OfferRequests.ts
@@ -1,0 +1,28 @@
+export interface AddOfferRequest {
+  id_company: number;
+  title: string;
+  body: string;
+  salary: number;
+  address: string;
+  status: string;
+  // TODO: Add skills, education, experiences and languages.
+}
+
+export interface UpdateOfferRequest {
+  id: number;
+  title: string | undefined;
+  body: string | undefined;
+  salary: number | undefined;
+  address: string | undefined;
+  status: string | undefined;
+}
+
+export interface RemoveOfferRequest {
+  id: number;
+}
+
+export interface GetOfferByIdRequest {
+  id: number;
+}
+
+export interface GetAllOffersRequest {}

--- a/src/formats/OfferRequests.ts
+++ b/src/formats/OfferRequests.ts
@@ -2,10 +2,15 @@ export interface AddOfferRequest {
   id_company: number;
   title: string;
   body: string;
-  salary: number;
+  minSalary: number;
+  maxSalary: number;
   address: string;
-  status: string;
-  // TODO: Add skills, education, experiences and languages.
+  status?: string;
+  image: string;
+  skills: number[];
+  education: number[];
+  experiences: number[];
+  languages: { id: number; level: string }[];
 }
 
 export interface UpdateOfferRequest {
@@ -15,6 +20,10 @@ export interface UpdateOfferRequest {
   salary: number | undefined;
   address: string | undefined;
   status: string | undefined;
+  skills: number[] | undefined;
+  education: number[] | undefined;
+  experiences: number[] | undefined;
+  languages: { id: number; level: string }[] | undefined;
 }
 
 export interface RemoveOfferRequest {

--- a/src/formats/OfferResponses.ts
+++ b/src/formats/OfferResponses.ts
@@ -10,7 +10,17 @@ export interface UpdateOfferResponse
 export interface RemoveOfferResponse {}
 
 export interface GetOfferByIdResponse
-  extends InferSelectModel<typeof jobOffersTable> {}
+  extends InferSelectModel<typeof jobOffersTable> {
+  skills: { id: number; name: string; type: string; category: string }[];
+  education: { id: number; domain: string; diploma: string }[];
+  experiences: { id: number; name: string }[];
+  languages: { id: number; name: string; level: string }[];
+}
 
 export interface GetOffersResponse
-  extends Array<InferSelectModel<typeof jobOffersTable>> {}
+  extends Array<InferSelectModel<typeof jobOffersTable>> {
+  skills: { id: number; name: string; type: string; category: string }[];
+  education: { id: number; domain: string; diploma: string }[];
+  experiences: { id: number; name: string }[];
+  languages: { id: number; name: string; level: string }[];
+}

--- a/src/formats/OfferResponses.ts
+++ b/src/formats/OfferResponses.ts
@@ -1,0 +1,16 @@
+import { InferSelectModel } from "drizzle-orm";
+import { jobOffersTable } from "../db/schema";
+
+export interface AddOfferResponse
+  extends InferSelectModel<typeof jobOffersTable> {}
+
+export interface UpdateOfferResponse
+  extends InferSelectModel<typeof jobOffersTable> {}
+
+export interface RemoveOfferResponse {}
+
+export interface GetOfferByIdResponse
+  extends InferSelectModel<typeof jobOffersTable> {}
+
+export interface GetOffersResponse
+  extends Array<InferSelectModel<typeof jobOffersTable>> {}

--- a/src/formats/UserRequests.ts
+++ b/src/formats/UserRequests.ts
@@ -5,7 +5,7 @@ export interface RegisterCandidateRequest {
   phone?: string;
   password: string;
   birthdate: Date | string;
-  address?: string;
+  address: string;
 }
 
 export interface RegisterCompanyRequest {

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@ import express, { Express, Request, Response } from "express";
 import CandidateRoutes from "./routes/CandidateRoutes";
 import CompanyRoutes from "./routes/CompanyRoutes";
 import AuthenticationRoutes from "./routes/AuthenticationRoutes";
+import OfferRoutes from "./routes/OfferRoutes";
 
 const app: Express = express();
 const port = process.env.PORT || 3000;
@@ -17,6 +18,7 @@ app.use("/auth", AuthenticationRoutes);
 
 app.use("/candidates", CandidateRoutes);
 app.use("/companies", CompanyRoutes);
+app.use("/offers", OfferRoutes);
 
 app.listen(port, () => {
   console.log(`[server]: Server is running at http://localhost:${port}`);

--- a/src/routes/OfferRoutes.ts
+++ b/src/routes/OfferRoutes.ts
@@ -1,0 +1,93 @@
+import { Router } from "express";
+import {
+  AddOffer,
+  GetAllOffers,
+  GetOfferById,
+  RemoveOffer,
+  UpdateOffer,
+} from "../controllers/OfferController";
+import { ErrorResponse } from "../formats/ErrorResponse";
+
+const router = Router();
+
+// Create a new offer
+router.post("/", async (request, response) => {
+  const controllerResponse = await AddOffer(request.body);
+  if (!controllerResponse) {
+    response.status(401).send("Could not add offer.");
+    return;
+  }
+
+  response.json(controllerResponse);
+});
+
+// Update an offer
+router.patch("/:id", async (request, response) => {
+  // TODO: Check id and validate data
+  const controllerResponse = await UpdateOffer({
+    ...request.body,
+    id: request.params.id,
+  });
+  if (!controllerResponse) {
+    response.status(401).send("Could not update offer.");
+    return;
+  }
+
+  response.json(controllerResponse);
+});
+
+// Remove an offer
+router.delete("/:id", async (request, response) => {
+  const id: number = parseInt(request.params.id);
+  if (isNaN(id)) {
+    response
+      .status(400)
+      .json(
+        new ErrorResponse(
+          "Invalid format for id. id must be a number.",
+          new TypeError("Not a number.")
+        )
+      );
+    return;
+  }
+
+  const controllerResponse = await RemoveOffer({ id });
+  if (!controllerResponse) {
+    response.status(404).send("Offer not found.");
+    return;
+  }
+  response.json(controllerResponse);
+});
+
+// Get an offer by its ID
+router.get("/:id", async (request, response) => {
+  const id: number = parseInt(request.params.id);
+  if (isNaN(id)) {
+    response
+      .status(400)
+      .json(
+        new ErrorResponse(
+          "Invalid format for id. id must be a number.",
+          new TypeError("Not a number.")
+        )
+      );
+    return;
+  }
+
+  const controllerResponse = await GetOfferById({ id });
+  if (!controllerResponse) {
+    response.status(404).send("Offer not found.");
+    return;
+  }
+
+  response.json(controllerResponse);
+});
+
+// Get all offers
+router.get("/", async (request, response) => {
+  const controllerResponse = await GetAllOffers({});
+
+  response.json(controllerResponse);
+});
+
+export default router;

--- a/src/routes/OfferRoutes.ts
+++ b/src/routes/OfferRoutes.ts
@@ -7,6 +7,7 @@ import {
   UpdateOffer,
 } from "../controllers/OfferController";
 import { ErrorResponse } from "../formats/ErrorResponse";
+import { OfferNotFoundError } from "../exceptions/OfferExceptions";
 
 const router = Router();
 
@@ -74,13 +75,22 @@ router.get("/:id", async (request, response) => {
     return;
   }
 
-  const controllerResponse = await GetOfferById({ id });
-  if (!controllerResponse) {
-    response.status(404).send("Offer not found.");
+  try {
+    const controllerResponse = await GetOfferById({ id });
+    if (!controllerResponse) {
+      throw new OfferNotFoundError();
+    }
+    response.json(controllerResponse);
+  } catch (error: unknown) {
+    if (error instanceof OfferNotFoundError) {
+      response.status(404).send("Offer not found.");
+    } else {
+      response
+        .status(500)
+        .json(new ErrorResponse("Internal server error", error));
+    }
     return;
   }
-
-  response.json(controllerResponse);
 });
 
 // Get all offers


### PR DESCRIPTION
This pull request includes significant changes to the `AuthenticationController` and the addition of a new `OfferController` along with its associated repository. The changes enhance the functionality and structure of the codebase, particularly in handling offers and user authentication.

Enhancements to `AuthenticationController`:

* Added `address` and `company` fields to various test cases in `AuthenticationController.test.ts` to ensure comprehensive testing of user and company data. [[1]](diffhunk://#diff-6b54729600a77fc33a7e9c5ce17feaa9e86bff04f830d102371419ef0475cb4fR117) [[2]](diffhunk://#diff-6b54729600a77fc33a7e9c5ce17feaa9e86bff04f830d102371419ef0475cb4fR137) [[3]](diffhunk://#diff-6b54729600a77fc33a7e9c5ce17feaa9e86bff04f830d102371419ef0475cb4fR159) [[4]](diffhunk://#diff-6b54729600a77fc33a7e9c5ce17feaa9e86bff04f830d102371419ef0475cb4fR210) [[5]](diffhunk://#diff-6b54729600a77fc33a7e9c5ce17feaa9e86bff04f830d102371419ef0475cb4fR242)
* Updated the `registerCompany` method to include a `company` field with a placeholder value.

Introduction of `OfferController`:

* Created `OfferController.ts` with methods for adding, updating, removing, and retrieving offers, including handling related skills, education, experiences, and languages.

New Offer Repository:

* Added `IOfferRepository.ts` defining the contract for offer-related CRUD operations and the `OfferRepository.ts` implementing these operations, including methods for managing linked data such as skills and education. [[1]](diffhunk://#diff-24163bc140db70eccb03e6a486de529978107570767fadf6e4b39c70e29576f0R1-R110) [[2]](diffhunk://#diff-4d4809e530e9f8b6d0dfe452a50e541626214d4291357ee33fbfdccd0d3f9a16R1-R308)

Schema updates:

* Modified `schema.ts` to include new constraints and fields such as `unique` constraints, `userRoleEnum`, and mandatory fields for `address` and `company`. [[1]](diffhunk://#diff-4bccf0a85960664570150bcf86a66e64e825b88f02fe19c2e323e96f65e2d55fR8) [[2]](diffhunk://#diff-4bccf0a85960664570150bcf86a66e64e825b88f02fe19c2e323e96f65e2d55fL18-R26) [[3]](diffhunk://#diff-4bccf0a85960664570150bcf86a66e64e825b88f02fe19c2e323e96f65e2d55fL36-R39) [[4]](diffhunk://#diff-4bccf0a85960664570150bcf86a66e64e825b88f02fe19c2e323e96f65e2d55fL47-R66) [[5]](diffhunk://#diff-4bccf0a85960664570150bcf86a66e64e825b88f02fe19c2e323e96f65e2d55fL75-L87) [[6]](diffhunk://#diff-4bccf0a85960664570150bcf86a66e64e825b88f02fe19c2e323e96f65e2d55fL111-R113)