### PR TITLE
Authentication routes now return id and role on top of token

### DIFF
--- a/src/controllers/AuthenticationController.test.ts
+++ b/src/controllers/AuthenticationController.test.ts
@@ -103,7 +103,7 @@ describe("AuthenticationController", () => {
         birthdate: new Date(request.birthdate),
         address: request.address,
       });
-      expect(result).toEqual({ token: "mock-token" });
+      expect(result).toEqual({ id: 1, role: "candidate", token: "mock-token" });
     });
 
     it("should throw UserCreationError if the user already exists", async () => {
@@ -239,7 +239,7 @@ describe("AuthenticationController", () => {
         user: createdUser.id,
         name: request.name,
       });
-      expect(result).toEqual({ token: "mock-token" });
+      expect(result).toEqual({ id: 10, role: "company", token: "mock-token" });
     });
 
     // Other test cases...
@@ -361,7 +361,7 @@ describe("AuthenticationController", () => {
       user: createdUser.id,
       name: request.name,
     });
-    expect(result).toEqual({ token: "mock-token" });
+    expect(result).toEqual({ id: 10, role: "company", token: "mock-token" });
   });
 });
 
@@ -376,6 +376,7 @@ describe("logIn", () => {
       id: 1,
       email: "test@example.com",
       password: "hashedPassword123",
+      role: "candidate",
     };
 
     (mockUserRepository.prototype.findByEmail as jest.Mock).mockResolvedValue(
@@ -394,7 +395,7 @@ describe("logIn", () => {
       request.password,
       user.password
     );
-    expect(result).toEqual({ token: "mock-token" });
+    expect(result).toEqual({ id: 1, role: "candidate", token: "mock-token" });
   });
 
   it("should return null if the user is not found", async () => {

--- a/src/controllers/AuthenticationController.ts
+++ b/src/controllers/AuthenticationController.ts
@@ -65,9 +65,13 @@ export const registerCandidate = async (
 
   // Return a user token to keep them logged in
   const tokenProvider = new TokenProvider();
-  const token = tokenProvider.sign({ id: newUser.id, role: undefined }); // TODO: Add roles later...
+  const token = tokenProvider.sign({ id: newUser.id, role: "candidate" });
 
-  const response: RegisterResponse = { token: token };
+  const response: RegisterResponse = {
+    id: newUser.id,
+    role: "candidate",
+    token: token,
+  };
   return response;
 };
 
@@ -122,9 +126,13 @@ export const registerCompany = async (
 
   // Return a user token to keep them logged in
   const tokenProvider = new TokenProvider();
-  const token = tokenProvider.sign({ id: newUser.id, role: undefined }); // TODO: Add roles later...
+  const token = tokenProvider.sign({ id: newUser.id, role: "company" });
 
-  const response: RegisterResponse = { token: token };
+  const response: RegisterResponse = {
+    id: newUser.id,
+    role: "company",
+    token: token,
+  };
   return response;
 };
 
@@ -142,11 +150,13 @@ export const logIn = async (
     return null;
   }
 
-  // TODO: Get the corresponding candidate or company user and include their relevant info in the token
-
   const tokenProvider = new TokenProvider();
-  const token = tokenProvider.sign({ id: user.id, role: undefined }); // TODO: Add roles later...
+  const token = tokenProvider.sign({ id: user.id, role: user.role }); // TODO: Add roles later...
 
-  const response: LogInResponse = { token: token };
+  const response: LogInResponse = {
+    id: user.id,
+    role: user.role,
+    token: token,
+  };
   return response;
 };

--- a/src/formats/UserResponses.ts
+++ b/src/formats/UserResponses.ts
@@ -1,7 +1,11 @@
 export interface RegisterResponse {
+  id: number;
+  role: string;
   token: string;
 }
 
 export interface LogInResponse {
+  id: number;
+  role: string;
   token: string;
 }


### PR DESCRIPTION
Example of a response for the route `/candidates/register`: 
```json
{
    "id": 54,
    "role": "candidate",
    "token": "eyJhbGciOiJIUzUxMiIsInR5cCI6IkpXVCJ9.eyJpZCI6NTQsInJvbGUiOiJjYW5kaWRhdGUiLCJpYXQiOjE3Mzc2Njk4MzEsImV4cCI6MTczNzc1NjIzMSwiaXNzIjoicmVjcnV0ZXotbW9pLWJhY2tlbmQifQ.VAS5kkvmzZnR-iU3zhIjVEE_VkHPRk176TdVcs4aMJjE5wSDsB5GtP8WmZJ7CSXtM-8_1lhs5uFx7kYQKagpzg"
}
```