### PR TITLE
Routes return more info

### DIFF
--- a/src/controllers/CandidateController.ts
+++ b/src/controllers/CandidateController.ts
@@ -38,6 +38,11 @@ export const AboutCandidate = async (
   const candidate = await candidateRepository.findById(request.id);
   const user = await new UserRepository().findById(request.id);
 
+  const userLanguages = await candidateRepository.getCandidateLanguages(
+    request.id
+  );
+  const userHobbies = await candidateRepository.getCandidateHobbies(request.id);
+
   if (!candidate || !user) {
     throw new UserNotFoundError();
   }
@@ -52,6 +57,8 @@ export const AboutCandidate = async (
     birthdate: candidate.birthdate.toISOString(),
     lookingForTitle: candidate.lookingForTitle || undefined,
     lookingForExperience: candidate.lookingForExperience || undefined,
+    languages: userLanguages.languages,
+    hobbies: userHobbies.hobbies,
   };
 };
 

--- a/src/controllers/CandidateController.ts
+++ b/src/controllers/CandidateController.ts
@@ -17,6 +17,7 @@ import GeocodingProvider from "../providers/GeocodingProvider";
 import PasswordProvider from "../providers/PasswordProvider";
 import { UnauthorizedAccessError } from "../exceptions/GeneralExceptions";
 import EducationRepository from "../db/repositories/EducationRepository";
+import UserRepository from "../db/repositories/UserRepository";
 
 const passwordProvider = new PasswordProvider();
 const candidateRepository = new CandidateRepository();
@@ -35,13 +36,15 @@ export const AboutCandidate = async (
     // TODO: Do that.
   }
   const candidate = await candidateRepository.findById(request.id);
+  const user = await new UserRepository().findById(request.id);
 
-  if (!candidate) {
+  if (!candidate || !user) {
     throw new UserNotFoundError();
   }
 
   return {
     id: candidate.user,
+    email: user.email,
     firstname: candidate.firstname,
     lastname: candidate.lastname,
     phone: candidate.phone || undefined,

--- a/src/controllers/CandidateController.ts
+++ b/src/controllers/CandidateController.ts
@@ -187,3 +187,11 @@ export const DeleteCandidateEducation = async (
     request.id_education
   );
 };
+
+export const GetCandidateSkills = async (
+  id_candidate: number
+): Promise<{
+  skills: { id: number; name: string; type: string; category: string }[];
+}> => {
+  return await candidateRepository.getCandidateSkills(id_candidate);
+};

--- a/src/controllers/CompanyController.ts
+++ b/src/controllers/CompanyController.ts
@@ -21,8 +21,14 @@ export const AboutCompany = async (
     throw new Error("Company not found");
   }
 
+  const user = await companyRepository.findUser(company.id);
+  if (!user) {
+    throw new UserNotFoundError();
+  }
+
   return {
     id: company.id,
+    email: user.email,
     name: company.name,
     created_at: new Date(company.created_at),
     modified_at: new Date(company.modified_at),

--- a/src/controllers/OfferController.ts
+++ b/src/controllers/OfferController.ts
@@ -177,14 +177,22 @@ export const LikeOffer = async (
   if (userAlreadyLikes === false) {
     await offerRepository.like(request.id_offer, request.id_user);
   }
-  return {};
+
+  const number_of_liked_offers = (
+    await offerRepository.getLiked(request.id_user)
+  ).length;
+  return { liked_offers_number: number_of_liked_offers };
 };
 
 export const UnlikeOffer = async (
   request: LikeOfferRequest
 ): Promise<LikeOfferResponse> => {
   await offerRepository.unlike(request.id_offer, request.id_user);
-  return {};
+
+  const number_of_liked_offers = (
+    await offerRepository.getLiked(request.id_user)
+  ).length;
+  return { liked_offers_number: number_of_liked_offers };
 };
 
 export const ApplyOffer = async (

--- a/src/db/repositories/CandidateRepository.ts
+++ b/src/db/repositories/CandidateRepository.ts
@@ -5,11 +5,14 @@ import {
   educationsTable,
   experienceSkillsTable,
   experiencesTable,
+  languagesTable,
   projectsSkillsTable,
   projectsTable,
   skillsTable,
   userEducationsTable,
   userExperiencesTable,
+  userHobbiesTable,
+  usersLanguagesTable,
   usersTable,
 } from "../schema";
 import { db } from "..";
@@ -330,5 +333,47 @@ export default class CandidateRepository implements ICandidateRepository {
     const userSkills = userSkillsProjects.concat(userSkillsExperiences);
 
     return { skills: userSkills };
+  }
+
+  async getCandidateLanguages(
+    id_candidate: number
+  ): Promise<{ languages: { id: number; name: string; level: string }[] }> {
+    return {
+      languages: (
+        await db
+          .select({
+            id: usersLanguagesTable.id_language,
+            name: languagesTable.name,
+            level: usersLanguagesTable.level,
+          })
+          .from(usersLanguagesTable)
+          .where(eq(usersLanguagesTable.id_user, id_candidate))
+          .innerJoin(
+            languagesTable,
+            eq(languagesTable.id, usersLanguagesTable.id_language)
+          )
+      ).map((language) => ({
+        id: language.id as number,
+        name: language.name as string,
+        level: language.level as string,
+      })),
+    };
+  }
+
+  async getCandidateHobbies(
+    id_candidate: number
+  ): Promise<{ hobbies: { name: string }[] }> {
+    return {
+      hobbies: (
+        await db
+          .select({
+            name: userHobbiesTable.name,
+          })
+          .from(userHobbiesTable)
+          .where(eq(userHobbiesTable.id_user, id_candidate))
+      ).map((hobby) => ({
+        name: hobby.name as string,
+      })),
+    };
   }
 }

--- a/src/db/repositories/ICandidateRepository.ts
+++ b/src/db/repositories/ICandidateRepository.ts
@@ -148,4 +148,24 @@ export default interface ICandidateRepository {
   getCandidateSkills(id_candidate: number): Promise<{
     skills: { id: number; name: string; type: string; category: string }[];
   }>;
+
+  /**
+   * Retrieves the list of a candidate's languages
+   * @param id_candidate The ID of the candidate
+   */
+  getCandidateLanguages(id_candidate: number): Promise<{
+    languages: {
+      id: number;
+      name: string;
+      level: string;
+    }[];
+  }>;
+
+  /**
+   * Retrieves the list of a candidate's hobbies
+   * @param id_candidate The ID of the candidate
+   */
+  getCandidateHobbies(
+    id_candidate: number
+  ): Promise<{ hobbies: { name: string }[] }>;
 }

--- a/src/db/repositories/ICandidateRepository.ts
+++ b/src/db/repositories/ICandidateRepository.ts
@@ -140,4 +140,12 @@ export default interface ICandidateRepository {
    * @param id_education The ID of the education
    */
   DeleteEducation(id_candidate: number, id_education: number): Promise<void>;
+
+  /**
+   * Retrieves the list of a candidate's skills
+   * @param id_candidate The ID of the candidate
+   */
+  getCandidateSkills(id_candidate: number): Promise<{
+    skills: { id: number; name: string; type: string; category: string }[];
+  }>;
 }

--- a/src/db/repositories/IOfferRepository.ts
+++ b/src/db/repositories/IOfferRepository.ts
@@ -100,6 +100,8 @@ export default interface IOfferRepository {
   getAllWithLiked(userId: number): Promise<
     (Offer & {
       liked: boolean;
+      company_name: string;
+      applied: boolean;
       skills: { id: number; name: string; type: string; category: string }[];
       education: { id: number; domain: string; diploma: string }[];
       experiences: { id: number; name: string }[];
@@ -141,7 +143,9 @@ export default interface IOfferRepository {
    * Retrieves all offers that a user has liked
    * @param userId The id of the user to get liked offers for
    */
-  getLiked(userId: number): Promise<Offer[]>;
+  getLiked(
+    userId: number
+  ): Promise<(Offer & { company_name: string; applied: boolean })[]>;
 
   /**
    * Returns whether a user has liked a specific offer

--- a/src/formats/CandidateResponses.ts
+++ b/src/formats/CandidateResponses.ts
@@ -8,6 +8,12 @@ export interface AboutCandidateResponse {
   birthdate: string;
   lookingForTitle?: string;
   lookingForExperience?: number;
+  languages?: {
+    id: number;
+    name: string;
+    level: string;
+  }[];
+  hobbies?: { name: string }[];
 }
 
 export interface GetCandidateEducationResponse {

--- a/src/formats/CandidateResponses.ts
+++ b/src/formats/CandidateResponses.ts
@@ -1,5 +1,6 @@
 export interface AboutCandidateResponse {
   id: number;
+  email: string;
   firstname: string;
   lastname: string;
   phone?: string;

--- a/src/formats/CompanyResponses.ts
+++ b/src/formats/CompanyResponses.ts
@@ -1,9 +1,6 @@
 export interface AboutCompanyResponse {
-  // id: number;
-  // company_id: number;
-  // name: string;
-
   id: number; // ID of the company (NOT USER)
+  email: string;
   name: string;
   created_at: Date;
   modified_at: Date;

--- a/src/formats/OfferResponses.ts
+++ b/src/formats/OfferResponses.ts
@@ -60,9 +60,13 @@ export interface GetLikedOffersResponse
     InferSelectModel<typeof jobOffersTable> & { company_name: string }
   > {}
 
-export interface LikeOfferResponse {}
+export interface LikeOfferResponse {
+  liked_offers_number: number;
+}
 
-export interface UnlikeOfferResponse {}
+export interface UnlikeOfferResponse {
+  liked_offers_number: number;
+}
 
 export interface ApplyOfferResponse {
   id: number;

--- a/src/routes/CandidateRoutes.ts
+++ b/src/routes/CandidateRoutes.ts
@@ -5,6 +5,7 @@ import {
   AddCandidateEducation,
   DeleteCandidateEducation,
   GetCandidateEducations,
+  GetCandidateSkills,
   UpdateCandidate,
 } from "../controllers/CandidateController";
 import { UserNotFoundError } from "../exceptions/UserExceptions";
@@ -214,6 +215,15 @@ router.get("/:id/educations", async (request, response) => {
   const controllerResponse = await GetCandidateEducations({
     id_candidate: parseInt(request.params.id),
   });
+
+  response.json(controllerResponse);
+});
+
+// Get candidate skills
+router.get("/:id/skills", async (request, response) => {
+  const controllerResponse = await GetCandidateSkills(
+    parseInt(request.params.id)
+  );
 
   response.json(controllerResponse);
 });

--- a/src/routes/OfferRoutes.ts
+++ b/src/routes/OfferRoutes.ts
@@ -31,8 +31,6 @@ import {
   usersLanguagesTable,
 } from "../db/schema";
 import { eq, sql } from "drizzle-orm";
-import GeocodingProvider from "../providers/GeocodingProvider";
-import CandidateRepository from "../db/repositories/CandidateRepository";
 import OfferRepository from "../db/repositories/OfferRepository";
 
 const router = Router();


### PR DESCRIPTION
Added new info on routes:

**About companies `/companies/:id_company`**
- Added field `email` --> The email of the user associated with the company.


**About candidates `/candidates/:id_candidate`**
- Added field `email` --> The email of the user associated with the user.
- Added field `languages` for all the languages that the candidate knows.
- Added field `hobbies` for all the hobbies of the candidate.

Example response:
```json
{
  "id": 3,
  "email": "hugo.panel@efrei.net",
  "firstname": "Hugo",
  "lastname": "Panel",
  "address": "160 Avenue de Flandres",
  "birthdate": "2025-01-01T00:00:00.000Z",
  "languages": [
    {
      "id": 1,
      "name": "English",
      "level": "confirmed"
    },
    {
      "id": 2,
      "name": "French",
      "level": "native"
    },
    {
      "id": 3,
      "name": "Spanish",
      "level": "intermediate"
    },
    {
      "id": 4,
      "name": "German",
      "level": "beginner"
    },
    {
      "id": 5,
      "name": "Swedish",
      "level": "beginner"
    }
  ],
  "hobbies": [
    {
      "name": "Music"
    },
    {
      "name": "Photography"
    },
    {
      "name": "Programming"
    },
    {
      "name": "Fishing"
    },
    {
      "name": "Hiking"
    }
  ]
}
```

**List of offers `/offers/`**
- Added field `applied` to say if the candidate making the request has applied to the each offer or not.

**Like an offer `/offers/:id_offer/like`**
- Added field `liked_offers_number` to count the new number of liked offers.

**Unlike an offer `/offers/:id_offer/unlike`**
- Added field `liked_offers_number` to count the new number of liked offers.


See Postman for a list of complete up-to-date responses.